### PR TITLE
Avoid segfault when logistic regression model is null in msGenotyper.cpp. Fix #7

### DIFF
--- a/msGenotyper.cpp
+++ b/msGenotyper.cpp
@@ -1415,11 +1415,15 @@ int main(int argc, char const ** argv)
                 clear(reads);
             }
             //Use logistic regression model to get pValue for all reads at marker
-            predict_label = predict_probability(model_,probBig.x[i],prob_estimates);
+	    if (model_) {
+	            predict_label = predict_probability(model_,probBig.x[i],prob_estimates);
+        	    mapPerMarker[thisMarker][i].pValue = prob_estimates[0];
+	    } else {
+		    mapPerMarker[thisMarker][i].pValue = -1;
+	    }
             free(probBig.x[i]);
             if (i<idx)
                 free(prob.x[i]);
-            mapPerMarker[thisMarker][i].pValue = prob_estimates[0];
             appendValue(reads, mapPerMarker[thisMarker][i]);
         }
         free(prob.y);


### PR DESCRIPTION
Not sure if this is the correct approach, but it prevents the segfault.